### PR TITLE
feat(dispatcher): apply middlewares via iterator

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -82,7 +82,7 @@ func (d *Dispatcher) wrappedEndpointHandler(endpoint string) tb.HandlerFunc {
 	return func(c tb.Context) error {
 		mw := d.endpointsMiddlewares[endpoint]
 		if mw != nil && mw.Len() > 0 {
-			fn = internal.ApplyMiddleware(fn, mw)
+			fn = internal.ApplyMiddleware(fn, mw.IterateBackward)
 		}
 		return fn(c)
 	}

--- a/dispatcher/handler_storage.go
+++ b/dispatcher/handler_storage.go
@@ -38,77 +38,41 @@ func (hs handlerStorage) addRoute(r handlerRoute) (endpoint string) {
 	return
 }
 
-// getAllMiddlewares returns list with middlewares from all parent routers (including current)
-// and handler middlewares. It saves correct structure of execution middlewares.
+// overAllMiddlewares returns iterator with middlewares
+// from all parent routers (including current) and handler
+// middlewares.
+// It saves correct order of execution middlewares.
 //
 // For example
 //
-//	topRouter with middleware [A, B, C]
-//	r2 is child of topRouter with middlewares [X, Y, Z]
+//	root router with middleware [A, B, C]
+//	r2 is child of root with middlewares [X, Y, Z]
 //	handler routers is [1, 2]
 //	execution chain will [A -> B -> C -> X -> Y -> Z -> 1 -> 2]
-func (hr handlerRoute) getAllMiddlewares() *internal.MiddlewareList {
-	l := new(internal.MiddlewareList)
-	getMiddlewares(l, hr.router)
-	l.ExtendSlice(hr.Middlewares)
-	return l
-}
-
-// getMiddlewares recursively adds all middleware to the list.
-func getMiddlewares(l *internal.MiddlewareList, r *Router) {
-	// base case for stop.
-	if r == nil {
-		return
-	}
-	// fetch middlewares from top routers
-	if r.parent != nil {
-		getMiddlewares(l, r.parent)
-	}
-	l.Extend(r.mw)
-}
-
-func (hr handlerRoute) iterateMiddlewares(yield internal.Yield) {
+func (hr handlerRoute) overAllMiddlewares(yield internal.Yield) {
 	for i := len(hr.Middlewares) - 1; i >= 0; i-- {
 		if !yield(hr.Middlewares[i]) {
 			return
 		}
 	}
 
-	iterMwChain(hr.router, yield)
-}
-
-func iterMwChain(r *Router, yield internal.Yield) (next bool) {
-	if r == nil {
-		return false
-	}
-
-	for e := r.mw.Back(); e != nil; e = e.Prev() {
-		if !yield(e.Value) {
-			return false
+	for r := hr.router; r != nil; r = r.parent {
+		// don't use List.IterateBackward, because iter.Seq
+		// must be without return values.
+		// But without return value we can't catch stop signal from yield.
+		for e := r.mw.Back(); e != nil; e = e.Prev() {
+			if !yield(e.Value) {
+				return
+			}
 		}
-	}
 
-	if r.parent != nil {
-		if !iterMwChain(r.parent, yield) {
-			return false
-		}
 	}
-	return true
 }
 
 func (hr handlerRoute) run(c tb.Context) error {
 	callback := internal.ApplyMiddleware(
 		hr.Route.Handler.Execute,
-		hr.getAllMiddlewares(),
-	)
-
-	return callback(c)
-}
-
-func (hr handlerRoute) runIterator(c tb.Context) error {
-	callback := internal.IterateApply(
-		hr.Route.Handler.Execute,
-		hr.iterateMiddlewares,
+		hr.overAllMiddlewares,
 	)
 
 	return callback(c)

--- a/internal/container/list.go
+++ b/internal/container/list.go
@@ -69,3 +69,11 @@ func (e *Element[T]) Next() *Element[T] {
 func (e *Element[T]) Prev() *Element[T] {
 	return e.prev
 }
+
+func (l *List[T]) IterateBackward(yield func(value T) (next bool)) {
+	for e := l.tail; e != nil; e = e.prev {
+		if !yield(e.Value) {
+			return
+		}
+	}
+}

--- a/internal/middlewares.go
+++ b/internal/middlewares.go
@@ -16,3 +16,15 @@ func ApplyMiddleware(h tb.HandlerFunc, m *MiddlewareList) tb.HandlerFunc {
 	}
 	return h
 }
+
+type Yield = func(mw tb.MiddlewareFunc) (next bool)
+
+type Iter = func(yield Yield)
+
+func IterateApply(h tb.HandlerFunc, iterator Iter) tb.HandlerFunc {
+	iterator(func(mw tb.MiddlewareFunc) (next bool) {
+		h = mw(h)
+		return true
+	})
+	return h
+}

--- a/internal/middlewares.go
+++ b/internal/middlewares.go
@@ -7,21 +7,14 @@ import (
 
 type MiddlewareList = container.List[tb.MiddlewareFunc]
 
-// ApplyMiddleware is copy of tele.applyMiddleware.
-// For support middlewares in handlers we need packs middlewares independently
-// of telebot.
-func ApplyMiddleware(h tb.HandlerFunc, m *MiddlewareList) tb.HandlerFunc {
-	for e := m.Back(); e != nil; e = e.Prev() {
-		h = e.Value(h)
-	}
-	return h
-}
-
 type Yield = func(mw tb.MiddlewareFunc) (next bool)
 
+// Iter is copy iter.Seq[tb.MiddlewareFunc] from go1.22.
+// Now is module's go version in 1.21.
+// But the version increases to 1.22, the new syntax will be used.
 type Iter = func(yield Yield)
 
-func IterateApply(h tb.HandlerFunc, iterator Iter) tb.HandlerFunc {
+func ApplyMiddleware(h tb.HandlerFunc, iterator Iter) tb.HandlerFunc {
 	iterator(func(mw tb.MiddlewareFunc) (next bool) {
 		h = mw(h)
 		return true


### PR DESCRIPTION
For apply all middlewares we need to get all chain and iterate in backward.

Now for this uses double linked list. It makes N allocations, where N - count of all middlewares.
But after one call lists go to garbage.

Bases on new go1.22 rangefunc i create functions that uses same types.
Benchmark:
```diff
goos: windows
goarch: amd64
pkg: github.com/vitaliy-ukiru/telebot-filter/dispatcher
cpu: AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx
-BenchmarkMiddlewareJoinList-8            1178841               936.6 ns/op             264 B/op         11 allocs/op
+BenchmarkMiddlewareJoinIterator-8        4041327               336.9 ns/op              48 B/op          3 allocs/op
```
<details>
<summary>bench code</summary>

```go
package dispatcher

import (
	"testing"

	tf "github.com/vitaliy-ukiru/telebot-filter/telefilter"
	tb "gopkg.in/telebot.v3"
)

func stubMiddleware() tb.MiddlewareFunc {
	return func(next tb.HandlerFunc) tb.HandlerFunc {
		return next
	}
}

func stubHandler() tf.RawHandler {
	return tf.RawHandler{
		Callback: func(_ tb.Context) error {
			return nil
		},
	}
}

func newList(m ...tb.MiddlewareFunc) *internal.MiddlewareList {
	return container.NewListFromSlice(m)
}

var route = handlerRoute{
	router: &Router{
		parent: &Router{
			parent: &Router{
				mw: newList(
					stubMiddleware(),
					stubMiddleware(),
					stubMiddleware(),
				),
			},
			mw: newList(stubMiddleware()),
		},
		mw: newList(
			stubMiddleware(),
			stubMiddleware(),
			stubMiddleware(),
		),
	},
	Route: tf.Route{
		Handler: stubHandler(),
		Middlewares: []tb.MiddlewareFunc{
			stubMiddleware(),
			stubMiddleware(),
		},
	},
}

func BenchmarkMiddlewareJoinList(b *testing.B) {
	for i := 0; i < b.N; i++ {
		route.run(nil)
	}
}

func BenchmarkMiddlewareJoinIterator(b *testing.B) {
	for i := 0; i < b.N; i++ {
		route.runIterator(nil)
	}
}

```
